### PR TITLE
Min ada

### DIFF
--- a/src/Perun/Offchain.hs
+++ b/src/Perun/Offchain.hs
@@ -183,7 +183,7 @@ abort (AbortParams cId) = do
       (P.show channelParameters)
       (P.show funding)
 
--- sets the transaction values for forming the initial auction transaction (endpoint start)
+-- alternative way to open a channel "at once" with all funding in place
 open :: OpenParams -> Contract w s Text ()
 open OpenParams {..} = do
   unless (all isLegalOutValue spBalances) . throwError . pack $ printf "Unable to open channel with any balance below minimum Ada"
@@ -257,7 +257,7 @@ dispute (DisputeParams keys sst) = do
   logInfo @P.String $ printf "made dispute of new state %s" (P.show dState)
 
 --
--- close logic
+-- close channel
 --
 
 close :: CloseParams -> Contract w s Text ()
@@ -285,10 +285,6 @@ close (CloseParams keys sst) = do
       channelId
       (P.show channelParameters)
       (P.show balances)
-
---
--- close logic
---
 
 forceClose :: ForceCloseParams -> Contract w s Text ()
 forceClose (ForceCloseParams cId) = do

--- a/src/Perun/Onchain.hs
+++ b/src/Perun/Onchain.hs
@@ -360,9 +360,12 @@ mkChannelValidator cID oldDatum action ctx =
     getsValue :: PaymentPubKeyHash -> Integer -> Bool
     getsValue pkh v =
       (v == 0)
-        || (let outputsForParty = [o | o <- txInfoOutputs info,
-                                      toPubKeyHash (txOutAddress o) == Just (unPaymentPubKeyHash pkh),
-                                      txOutValue o == Ada.lovelaceValueOf v] in length outputsForParty == 1)
+        || ( let outputsForParty =
+                   [ o | o <- txInfoOutputs info, toPubKeyHash (txOutAddress o) == Just (unPaymentPubKeyHash pkh), txOutValue o == Ada.lovelaceValueOf v
+                   ]
+              in -- FIXME What if there are multiple parties with the same payment key (>= is dangerous though!!)
+                 length outputsForParty == 1
+           )
 
 --
 -- COMPILATION TO PLUTUS CORE

--- a/src/Perun/Onchain.hs
+++ b/src/Perun/Onchain.hs
@@ -24,6 +24,7 @@ module Perun.Onchain
     ChannelDatum (..),
     ChannelTypes,
     ChannelID,
+    minAda,
     ensureKnownCurrencies,
     isValidStateTransition,
     extractVerifiedState,
@@ -58,6 +59,9 @@ import qualified Prelude as P
 -- ON CHAIN PART
 --
 --
+
+minAda :: Integer
+minAda = getLovelace minAdaTxOut
 
 type ChannelID = Integer
 
@@ -214,6 +218,8 @@ mkChannelValidator cID oldDatum action ctx =
           traceIfFalse "value of script output does not reflect funding" (correctInputFunding && correctChannelFunding),
           -- check that every funding value increases monotonously
           traceIfFalse "invalid funding" (all (== True) (zipWith (<=) (funding oldDatum) (funding outputDatum))),
+          -- check that every funding value is greater or equal to the minAda requirement
+          traceIfFalse "funding value of less than minimum Ada" (all (>= minAda) (funding outputDatum)),
           -- check that parameters, state, time stay the same, disputed == false
           traceIfFalse "violated channel integrity" channelIntegrityAtFunding,
           -- check that the channel is marked as funded iff it is actually funded

--- a/src/Perun/Onchain.hs
+++ b/src/Perun/Onchain.hs
@@ -358,6 +358,8 @@ mkChannelValidator cID oldDatum action ctx =
     correctForceCloseSlotRange :: Bool
     correctForceCloseSlotRange = from (time oldDatum + fromMilliSeconds (DiffMilliSeconds (pTimeLock (channelParameters oldDatum)))) `contains` txInfoValidRange info
 
+    -- payoutForPk returns the sum of all the balances that belong to pk
+    -- in a given balance distribution for this channel
     payoutForPk :: [Integer] -> PaymentPubKeyHash -> Integer
     payoutForPk bals pk =
       foldl
@@ -366,7 +368,8 @@ mkChannelValidator cID oldDatum action ctx =
         0
         (zip (pPaymentPKs $ channelParameters oldDatum) bals)
 
-    -- Returns true if party h is payed value v in an output of the transaction
+    -- getsValue returns true iff the funds in the output of this transaction
+    -- belonging to pkh sum up to at least v
     getsValue :: PaymentPubKeyHash -> Integer -> Bool
     getsValue pkh v =
       (v == 0)

--- a/src/Perun/Onchain.hs
+++ b/src/Perun/Onchain.hs
@@ -360,14 +360,9 @@ mkChannelValidator cID oldDatum action ctx =
     getsValue :: PaymentPubKeyHash -> Integer -> Bool
     getsValue pkh v =
       (v == 0)
-        || ( let [o] =
-                   [ o'
-                     | o' <- txInfoOutputs info,
-                       txOutValue o' == Ada.lovelaceValueOf v
-                   ]
-              in -- FIXME is it a problem to assume empty stake part of address here?
-                 txOutAddress o == pubKeyHashAddress pkh Nothing
-           )
+        || (let outputsForParty = [o | o <- txInfoOutputs info,
+                                      toPubKeyHash (txOutAddress o) == Just (unPaymentPubKeyHash pkh),
+                                      txOutValue o == Ada.lovelaceValueOf v] in length outputsForParty == 1)
 
 --
 -- COMPILATION TO PLUTUS CORE

--- a/test/PerunPlutus/PerunSpec.hs
+++ b/test/PerunPlutus/PerunSpec.hs
@@ -224,7 +224,7 @@ instance ContractModel PerunModel where
     modifyContractState
       ( \case
           PerunModel Nothing -> P.error "Finalize only works on existing channels"
-          PerunModel (Just (s, tl, fx, f)) -> PerunModel . Just $ (s {final = True}, tl, fx, f)
+          PerunModel (Just (s, tl, fx, f)) -> PerunModel . Just $ (s {final = True, version = version s + 1}, tl, fx, f)
       )
   nextState (Wait duration) = wait duration
   nextState (MaliciousFund n _ _ _ _) = invariant >> wait n

--- a/test/PerunPlutus/TestCases.hs
+++ b/test/PerunPlutus/TestCases.hs
@@ -11,9 +11,9 @@ import PerunPlutus.Test.EvilContract
 import Plutus.Contract.Test
 import Plutus.Contract.Test.ContractModel
 import Test.QuickCheck
+import Test.QuickCheck (Property)
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck
-import Test.QuickCheck (Property)
 
 -- Testcases
 
@@ -30,17 +30,23 @@ defaultTimeLockSlots = 15
 defaultTimeLock :: Integer
 defaultTimeLock = 15 * 1000
 
+payoutTest :: (Wallet, Wallet) -> DL PerunModel ()
+payoutTest (wa, wf) = do
+  channelID <- forAllQ arbitraryQ
+  action $ Open wf [wa, wa] channelID [2_000_000, 2_000_000] defaultTimeLock
+  action Finalize
+  (ChannelState cid _ _ _, _, _, _) <- requireGetChannel "channel must be available after finalization"
+  action $ Close wa [wa, wa] cid
 
 -- | sameValuePayoutTest checks that the payout validation works if there are
 -- | multiple outputs with the same value
 sameValuePayoutTest :: (Wallet, Wallet, Wallet) -> DL PerunModel ()
 sameValuePayoutTest (wa, wb, wf) = do
   channelID <- forAllQ arbitraryQ
-  action $ Open wf [wa, wb] channelID [1_000_000, 1_000_000] defaultTimeLock
+  action $ Open wf [wa, wb] channelID [2_000_000, 2_000_000] defaultTimeLock
   action Finalize
   (ChannelState cid _ _ _, _, _, _) <- requireGetChannel "channel must be available after finalization"
   action $ Close wb [wa, wb] cid
-
 
 -- | honestPaymentTest test scenario:
 -- | a third party opens a channel between A and B,
@@ -237,8 +243,11 @@ aPaysB cs@(ChannelState _ bals v _) delta =
 propPerun :: Actions PerunModel -> Property
 propPerun = propRunActions_
 
+prop_payoutTest :: Property
+prop_payoutTest = withMaxSuccess 1 $ forAllDL (payoutTest (w1, w2)) propPerun
+
 prop_SameValuePayoutTest :: Property
-prop_SameValuePayoutTest = withMaxSuccess 1 $ forAllDL (honestPaymentTest (w1, w2, w3)) propPerun
+prop_SameValuePayoutTest = withMaxSuccess 1 $ forAllDL (sameValuePayoutTest (w1, w2, w3)) propPerun
 
 prop_HonestPaymentTest :: Property
 prop_HonestPaymentTest = withMaxSuccess 1 $ forAllDL (honestPaymentTest (w1, w2, w3)) propPerun

--- a/test/PerunPlutus/TestCases.hs
+++ b/test/PerunPlutus/TestCases.hs
@@ -30,8 +30,11 @@ defaultTimeLockSlots = 15
 defaultTimeLock :: Integer
 defaultTimeLock = 15 * 1000
 
-payoutTest :: (Wallet, Wallet) -> DL PerunModel ()
-payoutTest (wa, wf) = do
+-- | samePartySameValuePayout test checks that the payout validation works if
+-- | one party is represented twice in the channel with both
+-- | representations owning exactly equal balance
+samePartySameValuePayoutTest :: (Wallet, Wallet) -> DL PerunModel ()
+samePartySameValuePayoutTest (wa, wf) = do
   channelID <- forAllQ arbitraryQ
   action $ Open wf [wa, wa] channelID [2_000_000, 2_000_000] defaultTimeLock
   action Finalize
@@ -243,8 +246,8 @@ aPaysB cs@(ChannelState _ bals v _) delta =
 propPerun :: Actions PerunModel -> Property
 propPerun = propRunActions_
 
-prop_payoutTest :: Property
-prop_payoutTest = withMaxSuccess 1 $ forAllDL (payoutTest (w1, w2)) propPerun
+prop_samePartySameValuePayoutTest :: Property
+prop_samePartySameValuePayoutTest = withMaxSuccess 1 $ forAllDL (samePartySameValuePayoutTest (w1, w2)) propPerun
 
 prop_SameValuePayoutTest :: Property
 prop_SameValuePayoutTest = withMaxSuccess 1 $ forAllDL (sameValuePayoutTest (w1, w2, w3)) propPerun

--- a/test/PerunPlutus/TestCases.hs
+++ b/test/PerunPlutus/TestCases.hs
@@ -13,6 +13,7 @@ import Plutus.Contract.Test.ContractModel
 import Test.QuickCheck
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck
+import Test.QuickCheck (Property)
 
 -- Testcases
 
@@ -28,6 +29,18 @@ defaultTimeLockSlots = 15
 
 defaultTimeLock :: Integer
 defaultTimeLock = 15 * 1000
+
+
+-- | sameValuePayoutTest checks that the payout validation works if there are
+-- | multiple outputs with the same value
+sameValuePayoutTest :: (Wallet, Wallet, Wallet) -> DL PerunModel ()
+sameValuePayoutTest (wa, wb, wf) = do
+  channelID <- forAllQ arbitraryQ
+  action $ Open wf [wa, wb] channelID [1_000_000, 1_000_000] defaultTimeLock
+  action Finalize
+  (ChannelState cid _ _ _, _, _, _) <- requireGetChannel "channel must be available after finalization"
+  action $ Close wb [wa, wb] cid
+
 
 -- | honestPaymentTest test scenario:
 -- | a third party opens a channel between A and B,
@@ -223,6 +236,9 @@ aPaysB cs@(ChannelState _ bals v _) delta =
 
 propPerun :: Actions PerunModel -> Property
 propPerun = propRunActions_
+
+prop_SameValuePayoutTest :: Property
+prop_SameValuePayoutTest = withMaxSuccess 1 $ forAllDL (honestPaymentTest (w1, w2, w3)) propPerun
 
 prop_HonestPaymentTest :: Property
 prop_HonestPaymentTest = withMaxSuccess 1 $ forAllDL (honestPaymentTest (w1, w2, w3)) propPerun


### PR DESCRIPTION
This adds checks to the contract so that no balance can fall below the minimum Ada requirement during funding.
To our understanding, for a transaction to be valid, every output has to carry a minimum amout of Ada (currently 2 Ada). If we did not handle this requirement in the script, there would be possibilities for malicious parties to freeze the channel during funding by funding less than 2 Ada and thereby locking other funds.
We will also have to handle this in the backend for channel updates.