### PR TITLE
Update pab sdk

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,22 @@
--- Bump this if you need newer packages.
-index-state: 2022-02-22T20:47:03Z
+-- Custom repository for cardano haskell packages
+-- See https://github.com/input-output-hk/cardano-haskell-packages on how to use CHaP in a Haskell project.
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+index-state: 2023-02-20T00:00:00Z
+
+-- See CONTRIBUTING.adoc for how to update index-state
+index-state:
+  , hackage.haskell.org 2023-02-20T00:00:00Z
+  , cardano-haskell-packages 2022-12-22T00:00:00Z
 
 packages: perun-contract
           perun-client
@@ -15,19 +32,48 @@ benchmarks: true
 -- The only sensible test display option.
 test-show-details: streaming
 
--- cardano-addresses unit tests bring in some version constraint conflicts:
---
--- * it has strict aeson < 1.5 dep - this will be fixed in the next release.
 allow-newer:
-    *:aeson
-  , size-based:template-haskell
+  -- cardano-ledger packages need aeson >2, the following packages have a
+  -- too restictive upper bounds on aeson, so we relax them here. The hackage
+  -- trustees can make a revision to these packages cabal file to solve the
+  -- issue permanently.
+  , ekg:aeson
+  , ekg-json:aeson
+  , openapi3:aeson
+  , servant:aeson
+  , servant-client-core:aeson
+  , servant-server:aeson
 
 constraints:
-    aeson >= 2
+  -- cardano-prelude-0.1.0.0 needs
+  , protolude <0.3.1
+
+  -- cardano-ledger-byron-0.1.0.0 needs
+  , cardano-binary <1.5.0.1
+
+  -- plutus-core-1.0.0.1 needs
+  , cardano-crypto-class >2.0.0.0
+  , algebraic-graphs <0.7
+
+  -- cardano-ledger-core-0.1.0.0 needs
+  , cardano-crypto-class <2.0.0.1
+
+  -- cardano-crypto-class-2.0.0.0.1 needs
+  , cardano-prelude <0.1.0.1
+
+  -- dbvar from cardano-wallet needs
+  , io-classes <0.3.0.0
+
+  -- newer typed-protocols need io-classes>=0.3.0.0 which is incompatible with dbvar's constraint above
+  , typed-protocols==0.1.0.0
+
+  , aeson >= 2
+
   , hedgehog >= 1.1
---  , protolude < 0.3.1
-  -- TODO: remove when plutus will upgrade to 0.7
---  , algebraic-graphs <= 0.6.1
+
+  , resource-pool <0.4.0.0
+
+  , http2 <4.0.0
 
 -- The plugin will typically fail when producing Haddock documentation. However,
 -- in this instance you can simply tell it to defer any errors to runtime (which
@@ -40,8 +86,6 @@ package plutus-ledger
 package plutus-script-utils
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 package plutus-contract
-  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
-package perun-plutus
   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
 
 -- These packages appear in our dependency tree and are very slow to build.
@@ -66,33 +110,6 @@ package cardano-wallet-launcher
   optimization: False
 package cardano-wallet-core-integration
   optimization: False
-
---- Plutus apps revision from head from `next-node` 2022.09.27.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/plutus-apps.git
-  tag: e25565ae8bd8a5b06b095e8fdeec90ce1ba65773
-  subdir:
-    doc
-    freer-extras
-    playground-common
-    plutus-chain-index
-    plutus-chain-index-core
-    plutus-contract
-    plutus-example
-    plutus-contract-certification
-    plutus-ledger
-    plutus-ledger-constraints
-    plutus-pab
-    plutus-pab-executables
-    plutus-playground-server
-    plutus-script-utils
-    plutus-streaming
-    plutus-tx-constraints
-    plutus-use-cases
-    rewindable-index
-    web-ghc
-
 
 -- Direct dependency.
 -- Compared to others, cardano-wallet doesn't bump dependencies very often.
@@ -121,107 +138,28 @@ source-repository-package
 -- Direct dependency.
 source-repository-package
     type: git
-    location: https://github.com/input-output-hk/servant-purescript
-    tag: 44e7cacf109f84984cd99cd3faf185d161826963
-
--- Direct dependency.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/purescript-bridge
-    tag: 47a1f11825a0f9445e0f98792f79172efef66c00
-
--- Direct dependency.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/quickcheck-dynamic
-    tag: c272906361471d684440f76c297e29ab760f6a1e
-
--- TODO This is a compatibility shim to make it easier for our library dependencies to
--- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
--- work with aeson-2, library dependencies will need to be updated to no longer use
--- this compatibility shim and have bounds to indicate they work with aeson-2 only.
--- After this, the dependency to hw-aeson can be dropped.
-source-repository-package
-    type: git
-    location: https://github.com/sevanspowell/hw-aeson
-    tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
-
--- Using a fork until our patches can be merged upstream
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/optparse-applicative
-  tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
-
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/Win32-network
-    tag: 3825d3abf75f83f406c1f7161883c438dac7277d
+    location: https://github.com/Quviq/quickcheck-contractmodel
+    tag: cc43f13f98c704e0d53dbdef6a98367918f8c5c1
+    subdir:
+      contractmodel
 
 -- Should follow cardano-wallet.
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-addresses
     tag: b7273a5d3c21f1a003595ebf1e1f79c28cd72513
-    subdir: command-line
-            core
-
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-base
-    tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
     subdir:
-            base-deriving-via
-            binary
-            binary/test
-            cardano-crypto-class
-            cardano-crypto-praos
-            cardano-crypto-tests
-            orphans-deriving-via
-            measures
-            strict-containers
-            slotting
+      -- cardano-addresses-cli
+      command-line
+      -- cardano-addresses
+      core
 
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-crypto
-    tag: f73079303f663e028288f9f4a9e08bcca39a923e
-
--- Should follow cardano-node.
--- But in case there are failures with the plutus version, update to the latest
--- commit hash of the release/1.0.0 plutus branch.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/plutus
-  tag: a56c96598b4b25c9e28215214d25189331087244
-  subdir:
-    plutus-core
-    plutus-ledger-api
-    plutus-tx
-    plutus-tx-plugin
-    prettyprinter-configurable
-    stubs/plutus-ghc-stub
-    word-array
-
--- Should follow cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ekg-forward
-  tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
-
--- Should follow cardano-node
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-config
-  tag: 1646e9167fab36c0bff82317743b96efa2d3adaa
-
--- Should follow cardano-wallet.
+-- This is needed because we rely on an unreleased feature
+-- https://github.com/input-output-hk/cardano-ledger/pull/3111
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/cardano-ledger
-    tag: c7c63dabdb215ebdaed8b63274965966f2bf408f
+    tag: da3e9ae10cf9ef0b805a046c84745f06643583c2
     subdir:
       eras/alonzo/impl
       eras/alonzo/test-suite
@@ -247,125 +185,341 @@ source-repository-package
       libs/small-steps-test
       libs/non-integral
 
--- Should follow cardano-wallet.
--- More precisally, this should be a version compatible with the current
--- Cardano mainnet (>=1.35).
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-node
-    tag: 1.35.3
-    subdir:
-      cardano-api
-      cardano-git-rev
-      cardano-cli
-      cardano-node
-      cardano-submit-api
-      cardano-testnet
-      trace-dispatcher
-      trace-resources
-      trace-forward
-
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/cardano-prelude
-    tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
-    subdir: cardano-prelude
-            cardano-prelude-test
-
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/goblins
-    tag: cde90a2b27f79187ca8310b6549331e59595e7ba
-
--- Direct dependency.
--- Are you thinking of updating this tag to some other commit?
--- Please ensure that the commit you are about to use is the latest one from
--- the *develop* branch of this repo:
---   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
--- (not master!)
+-- -- The plugin will typically fail when producing Haddock documentation. However,
+-- -- in this instance you can simply tell it to defer any errors to runtime (which
+-- -- will never happen since you're building documentation).
+-- --
+-- -- So, any package using 'PlutusTx.compile' in the code for which you need to
+-- -- generate haddock documentation should use the following 'haddock-options'.
+-- package plutus-ledger
+--   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+-- package plutus-script-utils
+--   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+-- package plutus-contract
+--   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+-- package perun-plutus
+--   haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+-- 
+-- -- These packages appear in our dependency tree and are very slow to build.
+-- -- Empirically, turning off optimization shaves off ~50% build time.
+-- -- It also mildly improves recompilation avoidance.
+-- -- For dev work we don't care about performance so much, so this is okay.
+-- package cardano-ledger-alonzo
+--   optimization: False
+-- package ouroboros-consensus-shelley
+--   optimization: False
+-- package ouroboros-consensus-cardano
+--   optimization: False
+-- package cardano-api
+--   optimization: False
+-- package cardano-wallet
+--   optimization: False
+-- package cardano-wallet-core
+--   optimization: False
+-- package cardano-wallet-cli
+--   optimization: False
+-- package cardano-wallet-launcher
+--   optimization: False
+-- package cardano-wallet-core-integration
+--   optimization: False
 --
--- In particular we rely on the code from this PR:
---  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
--- being merged.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/iohk-monitoring-framework
-    tag: 066f7002aac5a0efc20e49643fea45454f226caa
-    subdir: contra-tracer
-            iohk-monitoring
-            plugins/backend-aggregation
-            plugins/backend-ekg
-            plugins/backend-monitoring
-            plugins/backend-trace-forwarder
-            plugins/scribe-systemd
-            tracer-transformers
-
--- Should follow cardano-wallet.
-source-repository-package
-    type: git
-    location: https://github.com/input-output-hk/ouroboros-network
-    tag: cb9eba406ceb2df338d8384b35c8addfe2067201
-    subdir:
-      monoidal-synchronisation
-      network-mux
-      ouroboros-consensus
-      ouroboros-consensus-byron
-      ouroboros-consensus-cardano
-      ouroboros-consensus-protocol
-      ouroboros-consensus-shelley
-      ouroboros-network
-      ouroboros-network-framework
-      ouroboros-network-testing
-      ntp-client
-
--- Should follow cardano-node.
+--- Plutus apps revision from head from `next-node` 2022.09.27.
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/io-sim
-  tag: 57e888b1894829056cb00b7b5785fdf6a74c3271
+  location: https://github.com/input-output-hk/plutus-apps.git
+  tag: v1.2.0
   subdir:
-    io-classes
-    io-sim
-    strict-stm
+    doc
+    freer-extras
+    plutus-chain-index
+    plutus-chain-index-core
+    plutus-contract
+    plutus-example
+    plutus-contract-certification
+    plutus-ledger
+    plutus-tx-constraints
+    cardano-node-emulator
+    pab-blockfrost
+    marconi-core
+    plutus-pab
+    plutus-pab-executables
+    plutus-script-utils
+    plutus-tx-constraints
+    plutus-use-cases
 
--- Should follow cardano-node.
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/typed-protocols
-  tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
-  subdir:
-    typed-protocols
-    typed-protocols-cborg
-    typed-protocols-examples
 
--- Should follow plutus.
--- https://github.com/Quid2/flat/pull/22 fixes a potential exception
--- when decoding invalid (e.g. malicious) text literals.
-source-repository-package
-    type: git
-    location: https://github.com/Quid2/flat
-    tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
-
--- Should follow cardano-wallet.
--- Until https://github.com/tibbe/ekg-json/pull/12 gets merged with aeson2 support
-source-repository-package
-  type: git
-  location: https://github.com/vshabanov/ekg-json
-  tag: 00ebe7211c981686e65730b7144fbf5350462608
-
--- Should follow cardano-wallet
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/hedgehog-extras
-  tag: 714ee03a5a786a05fc57ac5d2f1c2edce4660d85
-
-source-repository-package
-  type: git
-  location: https://github.com/blockfrost/blockfrost-haskell
-  tag: v0.4.0.0
-  subdir:
-    blockfrost-api
-    blockfrost-client-core
-    blockfrost-client
+-- -- Direct dependency.
+-- -- Compared to others, cardano-wallet doesn't bump dependencies very often.
+-- -- Making it a good place to start when bumping dependencies.
+-- -- As, for example, bumping the node first highly risks breaking API with the wallet.
+-- -- Unless early bug fixes are required, this is fine as the wallet tracks stable releases of the node.
+-- -- And it is indeed nice for plutus-apps to track stable releases of the node too.
+-- --
+-- -- The current version is dated 2022/08/10
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-wallet
+--     tag: 18a931648550246695c790578d4a55ee2f10463e
+--     subdir:
+--       lib/cli
+--       lib/core
+--       lib/core-integration
+--       lib/dbvar
+--       lib/launcher
+--       lib/numeric
+--       lib/shelley
+--       lib/strict-non-empty-containers
+--       lib/test-utils
+--       lib/text-class
+-- 
+-- -- Direct dependency.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/servant-purescript
+--     tag: 44e7cacf109f84984cd99cd3faf185d161826963
+-- 
+-- -- Direct dependency.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/purescript-bridge
+--     tag: 47a1f11825a0f9445e0f98792f79172efef66c00
+-- 
+-- -- Direct dependency.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/quickcheck-dynamic
+--     tag: c272906361471d684440f76c297e29ab760f6a1e
+-- 
+-- -- TODO This is a compatibility shim to make it easier for our library dependencies to
+-- -- be compatible with both aeson 1 & 2.  Once downstream projects are all upgraded to
+-- -- work with aeson-2, library dependencies will need to be updated to no longer use
+-- -- this compatibility shim and have bounds to indicate they work with aeson-2 only.
+-- -- After this, the dependency to hw-aeson can be dropped.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/sevanspowell/hw-aeson
+--     tag: b5ef03a7d7443fcd6217ed88c335f0c411a05408
+-- 
+-- -- Using a fork until our patches can be merged upstream
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/optparse-applicative
+--   tag: 7497a29cb998721a9068d5725d49461f2bba0e7a
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/Win32-network
+--     tag: 3825d3abf75f83f406c1f7161883c438dac7277d
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-addresses
+--     tag: b7273a5d3c21f1a003595ebf1e1f79c28cd72513
+--     subdir: command-line
+--             core
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-base
+--     tag: 0f3a867493059e650cda69e20a5cbf1ace289a57
+--     subdir:
+--             base-deriving-via
+--             binary
+--             binary/test
+--             cardano-crypto-class
+--             cardano-crypto-praos
+--             cardano-crypto-tests
+--             orphans-deriving-via
+--             measures
+--             strict-containers
+--             slotting
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-crypto
+--     tag: f73079303f663e028288f9f4a9e08bcca39a923e
+-- 
+-- -- Should follow cardano-node.
+-- -- But in case there are failures with the plutus version, update to the latest
+-- -- commit hash of the release/1.0.0 plutus branch.
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/plutus
+--   tag: a56c96598b4b25c9e28215214d25189331087244
+--   subdir:
+--     plutus-core
+--     plutus-ledger-api
+--     plutus-tx
+--     plutus-tx-plugin
+--     prettyprinter-configurable
+--     stubs/plutus-ghc-stub
+--     word-array
+-- 
+-- -- Should follow cardano-node
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/ekg-forward
+--   tag: 297cd9db5074339a2fb2e5ae7d0780debb670c63
+-- 
+-- -- Should follow cardano-node
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/cardano-config
+--   tag: 1646e9167fab36c0bff82317743b96efa2d3adaa
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-ledger
+--     tag: c7c63dabdb215ebdaed8b63274965966f2bf408f
+--     subdir:
+--       eras/alonzo/impl
+--       eras/alonzo/test-suite
+--       eras/babbage/impl
+--       eras/babbage/test-suite
+--       eras/byron/chain/executable-spec
+--       eras/byron/crypto
+--       eras/byron/crypto/test
+--       eras/byron/ledger/executable-spec
+--       eras/byron/ledger/impl
+--       eras/byron/ledger/impl/test
+--       eras/shelley/impl
+--       eras/shelley/test-suite
+--       eras/shelley-ma/impl
+--       eras/shelley-ma/test-suite
+--       libs/cardano-ledger-core
+--       libs/cardano-ledger-pretty
+--       libs/cardano-protocol-tpraos
+--       libs/cardano-data
+--       libs/vector-map
+--       libs/set-algebra
+--       libs/small-steps
+--       libs/small-steps-test
+--       libs/non-integral
+-- 
+-- -- Should follow cardano-wallet.
+-- -- More precisally, this should be a version compatible with the current
+-- -- Cardano mainnet (>=1.35).
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-node
+--     tag: 1.35.3
+--     subdir:
+--       cardano-api
+--       cardano-git-rev
+--       cardano-cli
+--       cardano-node
+--       cardano-submit-api
+--       cardano-testnet
+--       trace-dispatcher
+--       trace-resources
+--       trace-forward
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/cardano-prelude
+--     tag: bb4ed71ba8e587f672d06edf9d2e376f4b055555
+--     subdir: cardano-prelude
+--             cardano-prelude-test
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/goblins
+--     tag: cde90a2b27f79187ca8310b6549331e59595e7ba
+-- 
+-- -- Direct dependency.
+-- -- Are you thinking of updating this tag to some other commit?
+-- -- Please ensure that the commit you are about to use is the latest one from
+-- -- the *develop* branch of this repo:
+-- --   * <https://github.com/input-output-hk/iohk-monitoring-framework/commits/develop>
+-- -- (not master!)
+-- --
+-- -- In particular we rely on the code from this PR:
+-- --  * <https://github.com/input-output-hk/iohk-monitoring-framework/pull/622>
+-- -- being merged.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/iohk-monitoring-framework
+--     tag: 066f7002aac5a0efc20e49643fea45454f226caa
+--     subdir: contra-tracer
+--             iohk-monitoring
+--             plugins/backend-aggregation
+--             plugins/backend-ekg
+--             plugins/backend-monitoring
+--             plugins/backend-trace-forwarder
+--             plugins/scribe-systemd
+--             tracer-transformers
+-- 
+-- -- Should follow cardano-wallet.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/input-output-hk/ouroboros-network
+--     tag: cb9eba406ceb2df338d8384b35c8addfe2067201
+--     subdir:
+--       monoidal-synchronisation
+--       network-mux
+--       ouroboros-consensus
+--       ouroboros-consensus-byron
+--       ouroboros-consensus-cardano
+--       ouroboros-consensus-protocol
+--       ouroboros-consensus-shelley
+--       ouroboros-network
+--       ouroboros-network-framework
+--       ouroboros-network-testing
+--       ntp-client
+-- 
+-- -- Should follow cardano-node.
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/io-sim
+--   tag: 57e888b1894829056cb00b7b5785fdf6a74c3271
+--   subdir:
+--     io-classes
+--     io-sim
+--     strict-stm
+-- 
+-- -- Should follow cardano-node.
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/typed-protocols
+--   tag: 181601bc3d9e9d21a671ce01e0b481348b3ca104
+--   subdir:
+--     typed-protocols
+--     typed-protocols-cborg
+--     typed-protocols-examples
+-- 
+-- -- Should follow plutus.
+-- -- https://github.com/Quid2/flat/pull/22 fixes a potential exception
+-- -- when decoding invalid (e.g. malicious) text literals.
+-- source-repository-package
+--     type: git
+--     location: https://github.com/Quid2/flat
+--     tag: ee59880f47ab835dbd73bea0847dab7869fc20d8
+-- 
+-- -- Should follow cardano-wallet.
+-- -- Until https://github.com/tibbe/ekg-json/pull/12 gets merged with aeson2 support
+-- source-repository-package
+--   type: git
+--   location: https://github.com/vshabanov/ekg-json
+--   tag: 00ebe7211c981686e65730b7144fbf5350462608
+-- 
+-- -- Should follow cardano-wallet
+-- source-repository-package
+--   type: git
+--   location: https://github.com/input-output-hk/hedgehog-extras
+--   tag: 714ee03a5a786a05fc57ac5d2f1c2edce4660d85
+-- 
+-- source-repository-package
+--   type: git
+--   location: https://github.com/blockfrost/blockfrost-haskell
+--   tag: v0.4.0.0
+--   subdir:
+--     blockfrost-api
+--     blockfrost-client-core
+--     blockfrost-client

--- a/perun-client/app/Client/Main.hs
+++ b/perun-client/app/Client/Main.hs
@@ -19,7 +19,6 @@ import Data.Default
 import Data.Either
 import Data.Proxy
 import Data.Text (Text, pack)
-import Data.Text.Class (fromText)
 import Data.Text.Encoding (encodeUtf8)
 import GHC.TypeLits hiding (Mod)
 import Ledger (PaymentPubKeyHash (..))
@@ -33,7 +32,7 @@ import Plutus.PAB.Types (Config (..), WebserverConfig (..), defaultWebServerConf
 import qualified PlutusTx.Builtins as Builtins
 import Servant.Client.Core.BaseUrl (BaseUrl (..), Scheme (..))
 import System.Random.Stateful
-import Wallet.Emulator.Wallet (Wallet (..), WalletId (..))
+import Wallet.Emulator.Wallet (Wallet (..), WalletId (..), fromBase16)
 import Prelude hiding (concat)
 
 data CmdLineArgs = CLA
@@ -77,7 +76,7 @@ cmdLineParser =
       )
   where
     parseWallet :: Mod OptionFields String -> Parser Wallet
-    parseWallet opts = Wallet Nothing . WalletId . right . fromText . pack <$> strOption opts
+    parseWallet opts = Wallet Nothing . right . fromBase16 . pack <$> strOption opts
     right (Right a) = a
     right _ = error "parsing failed"
     parseChannelId :: Mod OptionFields String -> Parser (Maybe ChannelID)
@@ -125,7 +124,7 @@ main = execParser opts >>= main'
         (fullDesc <> progDesc "Perun Client Application")
 
 walletId :: Wallet -> Types.WalletId
-walletId (Wallet _ (WalletId wid)) = wid
+walletId (Wallet _ (WalletId wid)) = Types.WalletId wid
 
 main' :: CmdLineArgs -> IO ()
 main' (CLA aliceWallet bobWallet network mChanId) = do

--- a/perun-client/src/Perun/Client/Client.hs
+++ b/perun-client/src/Perun/Client/Client.hs
@@ -189,7 +189,7 @@ privateKeyFromMnemonic (mnemonic, passphrase) =
     passphrase
 
 walletIdFromWallet :: Wallet -> Types.WalletId
-walletIdFromWallet (Wallet _ (WalletId wid)) = wid
+walletIdFromWallet (Wallet _ (WalletId wid)) = Types.WalletId wid
 
 addressFromApi :: AT.ApiAddress n -> Types.Address
 addressFromApi = AT.getApiT . fst . AT.id

--- a/perun-contract/perun-contract.cabal
+++ b/perun-contract/perun-contract.cabal
@@ -127,8 +127,15 @@ test-suite perun-contract-test
                     , plutus-ledger
                     , plutus-tx-constraints
                     , plutus-ledger-api
+                    , plutus-chain-index-core
                     , plutus-tx
+                    , plutus-script-utils
                     , lens
                     , text
                     , extra
                     , bytestring
+                    , freer-simple
+                    , freer-extras
+                    , mtl
+                    , quickcheck-dynamic
+                    , contractmodel

--- a/perun-contract/perun-contract.cabal
+++ b/perun-contract/perun-contract.cabal
@@ -50,7 +50,6 @@ library
                    , Perun.Adjudicator
                    , Perun.Adjudicator.History
                    , Perun.Adjudicator.Adjudicator
-                   , Perun.Orphans
 
     -- Modules included in this library but not exported.
     other-modules:   Perun.Offchain.ChannelTxPool.ChannelTxPool

--- a/perun-contract/perun-contract.cabal
+++ b/perun-contract/perun-contract.cabal
@@ -88,13 +88,14 @@ library
                       , bytestring
                       , data-default
                       , openapi3
+                      , cardano-node-emulator
                       , plutus-ledger
+                      , plutus-pab
                       , plutus-ledger-api
-                      , plutus-ledger-constraints
+                      , plutus-tx-constraints
                       , plutus-script-utils
                       , plutus-tx-plugin
                       , plutus-chain-index-core
-                      , playground-common
                       , plutus-tx
                       , lens
                       , text
@@ -125,7 +126,7 @@ test-suite perun-contract-test
                     , aeson
                     , containers
                     , plutus-ledger
-                    , plutus-ledger-constraints
+                    , plutus-tx-constraints
                     , plutus-ledger-api
                     , plutus-tx
                     , lens

--- a/perun-contract/src/Perun/Adjudicator/Adjudicator.hs
+++ b/perun-contract/src/Perun/Adjudicator/Adjudicator.hs
@@ -5,6 +5,7 @@ module Perun.Adjudicator.Adjudicator
   )
 where
 
+import Cardano.Node.Emulator.Params (pNetworkId)
 import Control.Lens hiding (index, para)
 import Control.Monad (unless)
 import Control.Monad.Error.Lens
@@ -26,7 +27,6 @@ import Plutus.ChainIndex hiding (tip, txFromTxId)
 import Plutus.Contract
 import Plutus.Contract.Types (Promise (..))
 import Plutus.Contract.Util (loopM)
-import qualified Plutus.Script.Utils.V1.Typed.Scripts as Typed
 import qualified Plutus.Script.Utils.V2.Typed.Scripts as Scripts
 import qualified PlutusTx
 
@@ -141,12 +141,13 @@ waitForUpdate ::
     e
     (Promise PerunEvent s e ChannelWaitingResult)
 waitForUpdate cID = do
+  networkId <- pNetworkId <$> getParams
   currentState <- getOnChainState cID
   let projectThree = (\(a, (b, c)) -> (a, b, c))
       projectFst = (\(a, (b, _)) -> (a, b))
       success = case currentState of
         Left NoOnchainStatesFoundErr -> do
-          let addr = channelAddress cID
+          let addr = channelCardanoAddress networkId cID
               -- waitForStart waits for the channel to be created.
               waitForStart = promiseBind (utxoIsProduced addr) $ \ciTx -> do
                 logInfo @String $ unwords ["Initial on-chain state UTxO produced at:", show addr]
@@ -156,7 +157,7 @@ waitForUpdate cID = do
                     -- ciTx, retry after sync.
                     r | null (concat r) -> retryAfterSync $ Control.Lens.traverse utxosTxOutTxFromTx ciTx
                     outRefMaps -> return outRefMaps
-                let produced = getStart cID (map projectThree . concat $ outRefMaps)
+                let produced = getStart cID networkId (map projectThree . concat $ outRefMaps)
                 -- If UTXOs were produced at the channel address and DID NOT
                 -- contain a start state, we continue waiting for channel
                 -- creation.
@@ -175,7 +176,7 @@ waitForUpdate cID = do
                         r | null r -> retryAfterSync $ utxosTxOutTxFromTx txn
                         result -> return result
                     )
-            let newStates = getStates cID (typedChannelValidator cID) outRefMap
+            let newStates = getStates cID networkId (typedChannelValidator cID) outRefMap
             case newStates of
               [] -> pure $ ChannelEnded currentOcs
               xs -> case chooser xs of
@@ -204,15 +205,15 @@ parseChannelAction (OnChainState iref) citx = do
       retryAfterSync action
     action = do
       let cInputs = citx ^. citxInputs
-          ir = Typed.tyTxOutRefRef iref
+          ir = Scripts.tyTxOutRefRef iref
       txIn <- case find ((== ir) . txInRef) cInputs of
         Just txIn -> return txIn
         _else -> throwing _SubscriptionError NoInputMatchingOnChainStateRefErr
       logInfo @String $ unwords ["Found channel input:", show txIn]
       rawAction <- case txInType txIn of
-        Just (ConsumeScriptAddress (Versioned _s _) rawAction _datum) ->
+        Just (ScriptAddress (Left (Versioned _s _)) rawAction _datum) ->
           return rawAction
-        _else -> parseChannelActionRedeemer (Typed.tyTxOutRefRef iref) citx
+        _else -> parseChannelActionRedeemer (Scripts.tyTxOutRefRef iref) citx
       logInfo @String $ unwords ["Found channel action:", show rawAction]
       case PlutusTx.fromBuiltinData . getRedeemer $ rawAction of
         Just channelAction -> do
@@ -369,9 +370,10 @@ getOnChainState ::
   ChannelID ->
   Contract PerunEvent s e (Either SubscriptionException OnChainState)
 getOnChainState cID = do
-  utxoTx <- utxosAt $ channelAddress cID
+  networkId <- pNetworkId <$> getParams
+  utxoTx <- utxosAt $ channelCardanoAddress networkId cID
   logInfo @String $ unwords ["querying onchain state for channel", show cID]
-  let states = getStates cID (typedChannelValidator cID) (Map.toList utxoTx)
+  let states = getStates cID networkId (typedChannelValidator cID) (Map.toList utxoTx)
   logInfo @String $ unwords ["found", show . length $ states, "onchain states"]
   return $ chooser states
 
@@ -392,8 +394,8 @@ chooser ocs =
           show . length $ ocs
         ]
 
-getStart :: ChannelID -> [(TxOutRef, L.ChainIndexTxOut, ChainIndexTx)] -> Either ChannelTxErr OnChainState
-getStart cid refMap = do
+getStart :: ChannelID -> NetworkId -> [(TxOutRef, DecoratedTxOut, ChainIndexTx)] -> Either ChannelTxErr OnChainState
+getStart cid networkId refMap = do
   let ctmap = rights $ map resolveChannelToken refMap
   case find isStartState ctmap of
     Just (_, _, _, _, tyTxOutRef) -> return . OnChainState $ tyTxOutRef
@@ -412,26 +414,28 @@ getStart cid refMap = do
       d <- parseDatumFromOutputDatum citx rawDatum
       cd <- channelDatumFromDatum d
       -- Create the typed TxOutRef version for the given txOutRef.
-      tyTxOutRef <- case Typed.typeScriptTxOutRef tcv txOutRef (toTxOut lCiTxOut) d of
+      tyTxOutRef <- case Scripts.typeScriptTxOutRef tcv txOutRef (toTxInfoTxOut lCiTxOut) d of
         Left _ -> throwError InvalidTxOutRefErr
         Right tyTxOutRef -> return tyTxOutRef
       return (ciTxOut, citx, d, cd, tyTxOutRef)
     isStartState (ciTxOut, _, _, cd, _) =
       let val = citoValue ciTxOut
-       in hasValidThreadToken cid (channelToken cd) val && isValidDatum cid cd
+       in hasValidThreadToken cid (channelToken cd) (fromCardanoValue val) && isValidDatum cid cd
 
-getStates :: ChannelID -> Scripts.TypedValidator ChannelTypes -> [(TxOutRef, L.ChainIndexTxOut)] -> [OnChainState]
-getStates cid tcv refMap =
+getStates :: ChannelID -> NetworkId -> Scripts.TypedValidator ChannelTypes -> [(TxOutRef, DecoratedTxOut)] -> [OnChainState]
+getStates cid networkId tcv refMap =
   flip mapMaybe refMap $ \(txOutRef, lciTxOut) -> do
-    let txOut = toTxOut lciTxOut
-    datum <- lciTxOut ^? ciTxOutScriptDatum . _2 . _Just
+    datum <-
+      lciTxOut ^? decoratedTxOutScriptDatum . _2 >>= \case
+        DatumInBody d -> Just d
+        _else -> Nothing
     ocsTxOutRef <- either (const Nothing) Just $ do
-      let val = lciTxOut ^. ciTxOutValue
-      tyTxOutRef <- case Typed.typeScriptTxOutRef tcv txOutRef txOut datum of
+      let val = lciTxOut ^. decoratedTxOutValue
+      tyTxOutRef <- case Scripts.typeScriptTxOutRef tcv txOutRef (toTxInfoTxOut lciTxOut) datum of
         Left _ -> throwError InvalidTxOutRefErr
         Right tyTxOutRef -> return tyTxOutRef
-      let ct = channelToken . Typed.tyTxOutData . Typed.tyTxOutRefOut $ tyTxOutRef
-      unless (hasValidThreadToken cid ct val) $ throwError InvalidThreadTokenErr
+      let ct = channelToken . Scripts.tyTxOutData . Scripts.tyTxOutRefOut $ tyTxOutRef
+      unless (hasValidThreadToken cid ct (fromCardanoValue val)) $ throwError InvalidThreadTokenErr
       pure tyTxOutRef
     pure $ OnChainState ocsTxOutRef
 

--- a/perun-contract/src/Perun/Adjudicator/Adjudicator.hs
+++ b/perun-contract/src/Perun/Adjudicator/Adjudicator.hs
@@ -167,7 +167,7 @@ waitForUpdate cID = do
                   Left err -> throwing _SubscriptionError $ ChannelErr err
           waitForStart
         Right currentOcs@(OnChainState ocsTxOutRef) -> do
-          promiseBind (utxoIsSpent (Typed.tyTxOutRefRef ocsTxOutRef)) $ \txn -> do
+          promiseBind (utxoIsSpent (Scripts.tyTxOutRefRef ocsTxOutRef)) $ \txn -> do
             logInfo @String $ unwords ["Found new onchain state for channel:", show cID]
             logInfo @String $ unwords ["Channel update executed in transaction:", show $ _citxTxId txn]
             outRefMap <-

--- a/perun-contract/src/Perun/Error.hs
+++ b/perun-contract/src/Perun/Error.hs
@@ -14,6 +14,7 @@ import Control.Lens
 import Data.Aeson
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import Ledger.Tx (ToCardanoError)
 import Perun.Adjudicator.History
 import Plutus.Contract
 
@@ -123,8 +124,11 @@ data ChannelTxErr
   | ChannelCorruptedChainIndexErr
   | WrongThreadTokenErr
   | InvalidChannelDatumErr
+  | SomeToCardanoErr !ToCardanoError
   | InvalidTxOutRefErr
   | InvalidThreadTokenErr
+  | PerunAsReferenceUnsupportedErr
+  | InlineDatumsUnsupportedErr
   deriving (Eq, Show, Generic)
   deriving anyclass (ToJSON, FromJSON)
 

--- a/perun-contract/src/Perun/Offchain/State.hs
+++ b/perun-contract/src/Perun/Offchain/State.hs
@@ -4,7 +4,7 @@ import Data.Aeson
 import GHC.Generics
 import Perun.Offchain.Event
 import Perun.Onchain
-import qualified Plutus.Script.Utils.V1.Typed.Scripts as Typed
+import qualified Plutus.Script.Utils.V2.Typed.Scripts as Scripts
 
 newtype PerunState = PChannel ChannelDatum
   deriving (Show, Generic)
@@ -13,11 +13,11 @@ newtype PerunState = PChannel ChannelDatum
 type PerunEvent = ChannelEventsLast
 
 perunState :: OnChainState -> ChannelDatum
-perunState (OnChainState ref) = Typed.tyTxOutData . Typed.tyTxOutRefOut $ ref
+perunState (OnChainState ref) = Scripts.tyTxOutData . Scripts.tyTxOutRefOut $ ref
 
 channelTokenFromOnChainState :: OnChainState -> ChannelToken
 channelTokenFromOnChainState = channelToken . perunState
 
 newtype OnChainState = OnChainState
-  { ocsTxOutRef :: Typed.TypedScriptTxOutRef ChannelTypes
+  { ocsTxOutRef :: Scripts.TypedScriptTxOutRef ChannelTypes
   }

--- a/perun-contract/src/Perun/Orphans.hs
+++ b/perun-contract/src/Perun/Orphans.hs
@@ -1,6 +1,0 @@
-module Perun.Orphans where
-
-import qualified Data.OpenApi as OpenApi
-import qualified Perun.Onchain as Perun
-
-instance OpenApi.ToSchema Perun.ChannelID

--- a/perun-contract/test/Perun/PerunSpec.hs
+++ b/perun-contract/test/Perun/PerunSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -21,13 +22,11 @@ module Perun.PerunSpec where
 import qualified Cardano.Crypto.Wallet as Crypto
 import Control.Lens hiding (both)
 import Control.Monad
+import Control.Monad.State
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Data
 import Data.Monoid (Last (..))
 import qualified Data.Semigroup as Semigroup
 import Ledger hiding (version)
-import qualified Ledger.Ada as Ada
-import qualified Ledger.Value as Value
 import Perun hiding (ChannelAction (..))
 import Perun.Error
 import Perun.Test.EvilContract
@@ -36,10 +35,12 @@ import qualified Plutus.Contract.Request as Trace
 import Plutus.Contract.Test (Wallet, mockWalletPaymentPubKey, mockWalletPaymentPubKeyHash, w1, w2, w3, w4)
 import Plutus.Contract.Test.ContractModel as CM
 import qualified Plutus.Contract.Types as ET
+import Plutus.Script.Utils.Ada as Ada
 import qualified Plutus.Trace.Effects.Assert as TA (assert)
 import Plutus.Trace.Effects.RunContract (ContractConstraints)
 import qualified Plutus.Trace.Emulator as Trace
 import qualified Plutus.Trace.Emulator.Types as ET
+import qualified Plutus.V1.Ledger.Value as Value
 import PlutusTx.Prelude hiding (mapM, unless)
 import Wallet.Emulator.MultiAgent as Emulator
 import qualified Wallet.Emulator.Wallet as Trace
@@ -54,7 +55,10 @@ adversaryWallets = [w4]
 exVal :: Value.Value
 exVal = Ada.lovelaceValueOf 1
 
-type PerunModel = Maybe PerunModelState
+newtype PerunModel = PerunModel
+  { _pmstate :: Maybe PerunModelState
+  }
+  deriving (Generic, P.Show, P.Eq)
 
 -- | PerunModelState
 data PerunModelState = PerunModelState
@@ -65,9 +69,10 @@ data PerunModelState = PerunModelState
     _chanFunded :: !Bool,
     _chanDisputed :: !Bool
   }
-  deriving (P.Show, P.Eq, Data)
+  deriving (Generic, P.Show, P.Eq)
 
 makeLenses ''PerunModelState
+makeLenses ''PerunModel
 
 deriving instance P.Eq (ContractInstanceKey PerunModel w schema err params)
 
@@ -110,8 +115,7 @@ instance ContractModel PerunModel where
     | MaliciousClose Integer Wallet ChannelID [Wallet] [Integer] CloseCase
     | MaliciousForceClose Integer Wallet ChannelID ForceCloseCase
     | MaliciousDispute Integer Wallet ChannelID [Wallet] [Integer] DisputeCase
-    deriving stock (P.Show, P.Eq)
-    deriving (Data)
+    deriving stock (Generic, P.Show, P.Eq)
 
   data ContractInstanceKey PerunModel w schema err param where
     -- Only one type of contract under test, so we define the
@@ -135,7 +139,7 @@ instance ContractModel PerunModel where
   arbitraryAction _ = P.undefined
 
   -- Initially there is not channel.
-  initialState = Nothing
+  initialState = PerunModel Nothing
 
   -- Opening a channel sets the agreed upon initial `ChannelState` for the
   -- channel.
@@ -143,8 +147,8 @@ instance ContractModel PerunModel where
   -- the balances for each wallet.
   nextState (Start parties cid startBalances timeLock _) = do
     ct <- createToken "ChannelToken"
-    modifyContractState $ \_ ->
-      Just $
+    modify $ \_ ->
+      PerunModel . Just $
         PerunModelState
           { _chanState =
               ChannelState
@@ -161,39 +165,39 @@ instance ContractModel PerunModel where
           }
     withdraw (head parties) . Ada.lovelaceValueOf $ head startBalances
     wait 1
-    CM.mint $ symAssetClassValue ct 1
+    CM.mint $ symAssetIdValue ct 1
   nextState (Fund funder idx _ _) = do
-    modifyContractState
+    modify
       ( \case
-          Nothing -> P.error "Funding only works on existing channels"
-          Just pms@(PerunModelState chst _ _tl oldFunding isFunded isDisputed)
+          PerunModel Nothing -> P.error "Funding only works on existing channels"
+          PerunModel (Just pms@(PerunModelState chst _ _tl oldFunding isFunded isDisputed))
             | isFunded || isDisputed -> P.error "Funding only works on unfunded & undisputed channels"
             | otherwise ->
-                let newFunding = addFunding (balances chst !! idx) idx oldFunding
-                 in Just $
-                      pms
-                        { _chanFunding = newFunding,
-                          _chanFunded = newFunding == balances chst
-                        }
+              let newFunding = addFunding (balances chst !! idx) idx oldFunding
+               in PerunModel . Just $
+                    pms
+                      { _chanFunding = newFunding,
+                        _chanFunded = newFunding == balances chst
+                      }
       )
     wait 3
     s <-
-      getContractState >>= \case
-        Nothing -> P.error "unable to read contract state"
-        Just ps -> return $ ps ^. chanState
+      get >>= \case
+        PerunModel Nothing -> P.error "unable to read contract state"
+        PerunModel (Just ps) -> return $ ps ^. chanState
     withdraw funder $ Ada.lovelaceValueOf (balances s !! idx)
   nextState (Abort _ parties _ _) = do
     (curFunding, token) <-
-      getContractState >>= \case
-        Nothing -> P.error "Abort only works on existing channels"
-        Just ps -> return (ps ^. chanFunding, ps ^. chanToken)
-    burn $ symAssetClassValue token 1
+      get >>= \case
+        PerunModel Nothing -> P.error "Abort only works on existing channels"
+        PerunModel (Just ps) -> return (ps ^. chanFunding, ps ^. chanToken)
+    burn $ symAssetIdValue token 1
     zipWithM_ deposit parties (map Ada.lovelaceValueOf curFunding)
     wait 1
   nextState (Open funder _ cid openBalances timeLock _) = do
     ct <- createToken "ChannelToken"
-    modifyContractState $ \_ ->
-      Just $
+    modify $ \_ ->
+      PerunModel . Just $
         PerunModelState
           { _chanState =
               ChannelState
@@ -211,48 +215,48 @@ instance ContractModel PerunModel where
     -- Move funds from chan -> Contract instance.
     withdraw funder $ Ada.lovelaceValueOf $ sum openBalances
     wait 1
-    CM.mint $ symAssetClassValue ct 1
+    CM.mint $ symAssetIdValue ct 1
   nextState (Update cs) = do
-    modifyContractState
+    modify
       ( \case
-          Nothing -> P.error "Update only works on existing channels"
-          (Just ps) -> Just $ ps & chanState .~ cs
+          PerunModel Nothing -> P.error "Update only works on existing channels"
+          PerunModel (Just ps) -> PerunModel . Just $ ps & chanState .~ cs
       )
   nextState Dispute {} = do
-    modifyContractState
+    modify
       ( \case
-          Nothing -> P.error "Dispute only works on existing channels"
-          Just pms
+          PerunModel Nothing -> P.error "Dispute only works on existing channels"
+          PerunModel (Just pms)
             | not (pms ^. chanFunded) -> P.error "Dispute only works on funded channels"
-            | otherwise -> Just $ pms & chanDisputed .~ True
+            | otherwise -> PerunModel . Just $ pms & chanDisputed .~ True
       )
     wait 3
   nextState (Close _ parties _ _) = do
     (s, t) <-
-      getContractState >>= \case
-        Nothing -> P.error "close only works on existing channels"
-        Just pms
+      get >>= \case
+        PerunModel Nothing -> P.error "close only works on existing channels"
+        PerunModel (Just pms)
           | not (pms ^. chanFunded) -> P.error "Close only works on funded channels"
           | otherwise -> return (pms ^. chanState, pms ^. chanToken)
     wait 1
-    burn $ symAssetClassValue t 1
+    burn $ symAssetIdValue t 1
     zipWithM_ deposit parties (map Ada.lovelaceValueOf (balances s))
   -- ForceClosing does nothing to the contract state, yet.
   nextState (ForceClose _ parties _ _) = do
     (s, t) <-
-      getContractState >>= \case
-        Nothing -> P.error "ForceClose only works on existing channels"
-        Just pms
+      get >>= \case
+        PerunModel Nothing -> P.error "ForceClose only works on existing channels"
+        PerunModel (Just pms)
           | not (pms ^. chanFunded) -> P.error "Close only works on funded channels"
           | otherwise -> return (pms ^. chanState, pms ^. chanToken)
-    burn $ symAssetClassValue t 1
+    burn $ symAssetIdValue t 1
     zipWithM_ deposit parties (map Ada.lovelaceValueOf (balances s))
     wait 1
   nextState Finalize =
-    modifyContractState
+    modify
       ( \case
-          Nothing -> P.error "Finalize only works on existing channels"
-          Just pms -> Just $ pms & chanState %~ \os -> os {final = True, version = version os + 1}
+          PerunModel Nothing -> P.error "Finalize only works on existing channels"
+          PerunModel (Just pms) -> PerunModel . Just $ pms & chanState %~ \os -> os {final = True, version = version os + 1}
       )
   nextState (Wait duration) = wait duration
   nextState (MaliciousFund n _ _ _ _) = invariant >> wait n
@@ -325,8 +329,8 @@ instance ContractModel PerunModel where
     Close issuer parties cid channelSymToken -> do
       let cs = s ^. contractState
       chan <- case cs of
-        Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
-        Just pms -> return $ pms ^. chanState
+        PerunModel Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
+        PerunModel (Just pms) -> return $ pms ^. chanState
       (ss, pks, _) <- verifiedSignedStateAndKeys parties chan
       Trace.callEndpoint @"close" (handle $ Participant issuer) (CloseParams cid (tokenMap channelSymToken) pks ss)
       delay 1
@@ -346,8 +350,8 @@ instance ContractModel PerunModel where
       p <- Trace.agentState w
       let sk = unPaymentPrivateKey . Trace.ownPaymentPrivateKey $ p
       chan <- case cs of
-        Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
-        Just pms -> return $ pms ^. chanState
+        PerunModel Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
+        PerunModel (Just pms) -> return $ pms ^. chanState
       (_, pks, _) <- verifiedSignedStateAndKeys parties chan
       requireInvalidTxEndpoint @"close" (handle $ Adversary w) (EvilClose cID (makeAllSignedStates [signMessage' (ChannelState (ChannelID "abc") [0] 0 False) sk]) pks bals c) "malicious closing should not work"
     MaliciousForceClose _ w cid c -> do
@@ -355,8 +359,8 @@ instance ContractModel PerunModel where
     MaliciousDispute _ w cid parties bals c -> do
       let cs = s ^. contractState
       chan <- case cs of
-        Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
-        Just pms -> return $ pms ^. chanState
+        PerunModel Nothing -> Trace.throwError . Trace.GenericError $ "no channel to close"
+        PerunModel (Just pms) -> return $ pms ^. chanState
       (ss, pks, _) <- verifiedSignedStateAndKeys parties chan
       requireInvalidTxEndpoint @"dispute" (handle $ Adversary w) (EvilDispute cid pks (map paymentPubKeyHash pks) bals ss c) "malicious dispute should not work"
 

--- a/perun-contract/test/Perun/PerunSpec.hs
+++ b/perun-contract/test/Perun/PerunSpec.hs
@@ -173,12 +173,12 @@ instance ContractModel PerunModel where
           PerunModel (Just pms@(PerunModelState chst _ _tl oldFunding isFunded isDisputed))
             | isFunded || isDisputed -> P.error "Funding only works on unfunded & undisputed channels"
             | otherwise ->
-              let newFunding = addFunding (balances chst !! idx) idx oldFunding
-               in PerunModel . Just $
-                    pms
-                      { _chanFunding = newFunding,
-                        _chanFunded = newFunding == balances chst
-                      }
+                let newFunding = addFunding (balances chst !! idx) idx oldFunding
+                 in PerunModel . Just $
+                      pms
+                        { _chanFunding = newFunding,
+                          _chanFunded = newFunding == balances chst
+                        }
       )
     wait 3
     s <-

--- a/perun-contract/test/Perun/Test/EvilContract.hs
+++ b/perun-contract/test/Perun/Test/EvilContract.hs
@@ -21,7 +21,7 @@ import qualified Data.Semigroup as Semigroup
 import GHC.Generics (Generic)
 import Ledger
 import qualified Ledger.Tx.Constraints as Constraints
-import Perun hiding (abort, close, dispute, findChannel, forceClose, fund, open, start)
+import Perun hiding (abort, close, dispute, forceClose, fund, open, start)
 import Perun.Error
 import Plutus.Contract
 import Plutus.Script.Utils.Ada as Ada
@@ -111,20 +111,6 @@ fund EvilFund {..} = do
     FundViolateChannelIntegrity -> fundViolateChannelIntegrity efChannelId
     FundInvalidFunded -> fundInvalidFunded efChannelId
     FundAlreadyFunded -> fundAlreadyFunded efChannelId
-
-findChannel ::
-  ChannelID ->
-  Contract w s PerunError (TxOutRef, ChainIndexTxOut, ChannelDatum)
-findChannel cID = do
-  utxos <- utxosAt $ channelAddress cID
-  case Map.toList utxos of
-    [(oref, o)] -> case _ciTxOutScriptDatum o of
-      (_, Just (Datum e)) -> case PlutusTx.fromBuiltinData e of
-        Nothing -> throwing _FindChannelError WrongDatumTypeError
-        Just d@ChannelDatum {} -> return (oref, o, d)
-      _otherwise -> throwing _FindChannelError DatumMissingError
-    [] -> throwing _FindChannelError NoUTXOsError
-    _utxos -> throwing _FindChannelError UnexpectedNumberOfUTXOsError
 
 fundViolateChannelIntegrity :: ChannelID -> Contract EvilContractState s PerunError ()
 fundViolateChannelIntegrity cid = do

--- a/perun-contract/test/Perun/Test/EvilContract.hs
+++ b/perun-contract/test/Perun/Test/EvilContract.hs
@@ -20,12 +20,13 @@ import Data.Map as Map hiding (map)
 import qualified Data.Semigroup as Semigroup
 import GHC.Generics (Generic)
 import Ledger
-import Ledger.Ada as Ada
-import qualified Ledger.Constraints as Constraints
+import qualified Ledger.Tx.Constraints as Constraints
 import Perun hiding (abort, close, dispute, findChannel, forceClose, fund, open, start)
 import Perun.Error
 import Plutus.Contract
+import Plutus.Script.Utils.Ada as Ada
 import qualified Plutus.V1.Ledger.Scripts as Scripts
+import qualified Plutus.V1.Ledger.Value as Value
 import qualified PlutusTx
 import PlutusTx.Prelude
 import Text.Printf (printf)
@@ -133,7 +134,7 @@ fundViolateChannelIntegrity cid = do
   let _newFunding = []
       newDatum = d {time = ct}
       r = Scripts.Redeemer (PlutusTx.toBuiltinData Fund)
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -146,7 +147,7 @@ fundInvalidFunded cid = do
   logInfo @P.String $ printf "EVIL_CONTRACT: found channel utxo with datum %s" (P.show d)
   let newDatum = d {funded = True}
       r = Scripts.Redeemer (PlutusTx.toBuiltinData Fund)
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -162,7 +163,7 @@ fundAlreadyFunded cid = do
       logInfo @P.String $ printf "EVIL_CONTRACT: found channel utxo with datum %s" (P.show d)
       let newDatum = d
           r = Scripts.Redeemer (PlutusTx.toBuiltinData Fund)
-          v = Ada.toValue minAdaTxOut
+          v = Ada.toValue minAdaTxOutEstimated
       ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
       void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
       tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -202,7 +203,7 @@ abortInvalidFunding cid = do
   logInfo @P.String $ printf "EVIL_CONTRACT: found channel utxo with datum %s" (P.show d)
   let newDatum = d
       r = Scripts.Redeemer (PlutusTx.toBuiltinData Abort)
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -225,7 +226,7 @@ closeUnfunded cid sst bals = do
   logInfo @P.String $ printf "EVIL_CONTRACT: found channel utxo with datum %s" (P.show d)
   let newDatum = d
       r = Scripts.Redeemer . PlutusTx.toBuiltinData . MkClose $ compressSignatures sst
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
       (lookups, tx) = uncheckedTx newDatum r cid v oref o
   ledgerTx <- submitTxConstraintsWith lookups (tx <> mconcat (zipWith Constraints.mustPayToPubKey (pPaymentPKs channelParameters) (map Ada.lovelaceValueOf bals)))
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
@@ -238,7 +239,7 @@ closeInvalidInputValue cid sst = do
   logInfo @P.String $ printf "EVIL_CONTRACT: found channel utxo with datum %s" (P.show d)
   let newDatum = d
       r = Scripts.Redeemer . PlutusTx.toBuiltinData . MkClose $ compressSignatures sst
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -255,7 +256,7 @@ forceCloseInvalidInput cid = do
   logInfo @P.String $ printf "found channel utxo with datum %s" (P.show d)
   let newDatum = d
       r = Scripts.Redeemer . PlutusTx.toBuiltinData $ ForceClose
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -298,7 +299,7 @@ disputeValidInput cid sst pubkeys = do
   logInfo @P.String $ printf "found channel utxo with datum %s" (P.show d)
   disputeWithDatum oref o cid sst d {state = dState, time = t, disputed = True}
 
-disputeWithDatum :: TxOutRef -> ChainIndexTxOut -> ChannelID -> AllSignedStates -> ChannelDatum -> Contract EvilContractState s PerunError ()
+disputeWithDatum :: TxOutRef -> DecoratedTxOut -> ChannelID -> AllSignedStates -> ChannelDatum -> Contract EvilContractState s PerunError ()
 disputeWithDatum oref o cid sst dat = do
   let newDatum = dat
       r = Scripts.Redeemer . PlutusTx.toBuiltinData . MkDispute $ compressSignatures sst
@@ -314,7 +315,7 @@ disputeInvalidInput cid sst = do
   logInfo @P.String $ printf "found channel utxo with datum %s" (P.show d)
   let newDatum = d
       r = Scripts.Redeemer . PlutusTx.toBuiltinData . MkDispute $ compressSignatures sst
-      v = Ada.toValue minAdaTxOut
+      v = Ada.toValue minAdaTxOutEstimated
   ledgerTx <- uncurry submitTxConstraintsWith $ uncheckedTx newDatum r cid v oref o
   void $ awaitTxConfirmed $ getCardanoTxId ledgerTx
   tell . Just . Semigroup.Last . getCardanoTxId $ ledgerTx
@@ -332,7 +333,7 @@ evilContract = selectList [fund', abort', dispute', close', forceClose'] >> evil
     close' = endpoint @"close" close
     forceClose' = endpoint @"forceClose" forceClose
 
-uncheckedTx :: PlutusTx.ToData o => o -> Scripts.Redeemer -> ChannelID -> Value -> TxOutRef -> ChainIndexTxOut -> (Constraints.ScriptLookups ChannelTypes, Constraints.TxConstraints ChannelAction o)
+uncheckedTx :: PlutusTx.ToData o => o -> Scripts.Redeemer -> ChannelID -> Value.Value -> TxOutRef -> DecoratedTxOut -> (Constraints.ScriptLookups ChannelTypes, Constraints.TxConstraints ChannelAction o)
 uncheckedTx d r cid v oref oidx = (lookups, tx)
   where
     lookups =

--- a/perun-pab/src/Perun/PAB.hs
+++ b/perun-pab/src/Perun/PAB.hs
@@ -61,9 +61,6 @@ instance Pretty StarterContracts where
 
 instance Builtin.HasDefinitions StarterContracts where
   getDefinitions = [PerunContract]
-  getSchema = \case
-    PerunContract -> Builtin.endpointsToSchemas @Perun.ChannelSchema
-    AdjudicatorContract _ -> Builtin.endpointsToSchemas @Perun.AdjudicatorSchema
   getContract = \case
     PerunContract -> SomeBuiltin Perun.contract
     AdjudicatorContract cID -> SomeBuiltin (Perun.adjudicatorSubscription cID)

--- a/perun-pab/src/Perun/PAB.hs
+++ b/perun-pab/src/Perun/PAB.hs
@@ -31,7 +31,6 @@ import GHC.Generics (Generic)
 import Perun.Adjudicator as Perun
 import Perun.Offchain as Perun
 import Perun.Onchain as Perun
-import Perun.Orphans ()
 import Plutus.PAB.Effects.Contract.Builtin (SomeBuiltin (..))
 import qualified Plutus.PAB.Effects.Contract.Builtin as Builtin
 import Prettyprinter (Pretty (..), viaShow)


### PR DESCRIPTION
This updates the project to use PAB SDK v1.2.0.
The on-chain scripts themselves did not change, but nearly everything else required some adaptation to imports or implementation.